### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/sys-proctree.gemspec
+++ b/sys-proctree.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |spec|
   spec.description = "Discovers and kills process trees via analysing running process lists"
   spec.email = "matthew.ueckerman@myob.com"
   spec.homepage = "http://github.com/MYOB-Technology/sys-proctree"
-  spec.rubyforge_project = "sys-proctree"
   spec.license = "MIT"
 
   spec.files        = Dir.glob("./lib/**/*")


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.